### PR TITLE
[QA-3033] Pytest reruns with fixtures invalidation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,17 @@
 Changelog
 ---------
 
-
-4.1 (unreleased)
+0.9 (2018-03-29)
 ================
+Forked based on pytest-rerunfailures v4.0 package:
+Changes:
 
-- Nothing changed yet.
+- Fixture invalidation for failed test
+
+- Test rerun will be xecuted with no cached fixtures
 
 
-4.0 (2017-12-23)
+pytest-rerunfailures 4.0 (2017-12-23)
 ================
 
 - Added option to add a delay time between test re-runs (Thanks to `@Kanguros`_
@@ -19,79 +22,3 @@ Changelog
 - Drop support for pytest < 2.8.7.
 
 .. _@Kanguros: https://github.com/Kanguros
-
-
-3.1 (2017-08-29)
-================
-
-- Restored compatibility with pytest-xdist. (Thanks to `@davehunt`_ for the PR)
-
-.. _@davehunt: https://github.com/davehunt
-
-
-3.0 (2017-08-17)
-================
-
-- Add support for Python 3.6.
-
-- Add support for pytest 2.9 up to 3.2
-
-- Drop support for Python 2.6 and 3.3.
-
-- Drop support for pytest < 2.7.
-
-
-2.2 (2017-06-23)
-================
-
-- Ensure that other plugins can run after this one, in case of a global setting
-  ``--rerun=0``. (Thanks to `@sublee`_ for the PR)
-
-.. _@sublee: https://github.com/sublee
-
-2.1.0 (2016-11-01)
-==================
-
-- Add default value of ``reruns=1`` if ``pytest.mark.flaky()`` is called
-  without arguments.
-
-- Also offer a distribution as universal wheel. (Thanks to `@tltx`_ for the PR)
-
-.. _@tltx: https://github.com/tltx
-
-
-2.0.1 (2016-08-10)
-==================
-
-- Prepare CLI options to pytest 3.0, to avoid a deprecation warning.
-
-- Fix error due to missing CHANGES.rst when creating the source distribution
-  by adding a MANIFEST.in.
-
-
-2.0.0 (2016-04-06)
-==================
-
-- Drop support for Python 3.2, since supporting it became too much of a hassle.
-  (Reason: Virtualenv 14+ / PIP 8+ do not support Python 3.2 anymore.)
-
-
-1.0.2 (2016-03-29)
-==================
-
-- Add support for `--resultlog` option by parsing reruns accordingly. (#28)
-
-
-1.0.1 (2016-02-02)
-==================
-
-- Improve package description and include CHANGELOG into description.
-
-
-1.0.0 (2016-02-02)
-==================
-
-- Rewrite to use newer API of pytest >= 2.3.0
-
-- Improve support for pytest-xdist by only logging the final result.
-  (Logging intermediate results will finish the test rather rerunning it.)

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,13 @@
-pytest-rerunfailures
+pytest-cleanrerun
 ====================
 
-pytest-rerunfailures is a plugin for `py.test <http://pytest.org>`_ that
-re-runs tests to eliminate intermittent failures.
-
-.. image:: https://img.shields.io/badge/license-MPL%202.0-blue.svg
-   :target: https://github.com/pytest-dev/pytest-rerunfailures/blob/master/LICENSE
-   :alt: License
-.. image:: https://img.shields.io/pypi/v/pytest-rerunfailures.svg
-   :target: https://pypi.python.org/pypi/pytest-rerunfailures/
-   :alt: PyPI
-.. image:: https://img.shields.io/travis/pytest-dev/pytest-rerunfailures.svg
-   :target: https://travis-ci.org/pytest-dev/pytest-rerunfailures/
-   :alt: Travis
+pytest-cleanrerun is a plugin for `py.test <http://pytest.org>`_ that
+re-runs tests to eliminate intermittent failures with failed tests related fixture invalidation.
 
 Requirements
 ------------
 
-You will need the following prerequisites in order to use pytest-rerunfailures:
+You will need the following prerequisites in order to use pytest-cleanrerun:
 
 - Python 2.7, 3.4, 3.5, 3.6, PyPy, or PyPy3
 - pytest 2.8.7 or newer
@@ -25,11 +15,11 @@ You will need the following prerequisites in order to use pytest-rerunfailures:
 Installation
 ------------
 
-To install pytest-rerunfailures:
+To install pytest-cleanrerun:
 
 .. code-block:: bash
 
-  $ pip install pytest-rerunfailures
+  $ pip install pytest-cleanrerun
 
 Re-run all failures
 -------------------
@@ -104,12 +94,11 @@ be marked as failed.
 Compatibility
 -------------
 
-* This plugin may *not* be used with class, module, and package level fixtures.
 * This plugin is *not* compatible with pytest-xdist's --looponfail flag.
 * This plugin is *not* compatible with the core --pdb flag.
 
 Resources
 ---------
 
-- `Issue Tracker <http://github.com/pytest-dev/pytest-rerunfailures/issues>`_
-- `Code <http://github.com/pytest-dev/pytest-rerunfailures/>`_
+- `Issue Tracker <https://github.com/datarobot/pytest-rerunfailures>`_
+- `Code <https://github.com/datarobot/pytest-rerunfailures>`_

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,9 @@ pytest-cleanrerun
 
 pytest-cleanrerun is a plugin for `py.test <http://pytest.org>`_ that
 re-runs tests to eliminate intermittent failures with failed tests related fixture invalidation.
+Added all scoped fixtures invalidation for current test item in case of test failure before rerun occurs.
+Plugin able to track all related fixtures: direct injects, autouse, usefixture mark.
+Fixtures invalidated gracefully with executing finalizer.
 
 Requirements
 ------------

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
 from setuptools import setup
 
-setup(name='pytest-rerunfailures',
-      version='4.1.dev0',
-      description='pytest plugin to re-run tests to eliminate flaky failures',
+setup(name='pytest-cleanrerun',
+      version='0.9',
+      description='pytest plugin to re-run tests with fixture invalidation to eliminate flaky failures',
       long_description=(
           open('README.rst').read() +
           '\n\n' +
           open('CHANGES.rst').read()),
-      author='Leah Klearman',
-      author_email='lklrmn@gmail.com',
-      url='https://github.com/pytest-dev/pytest-rerunfailures',
-      py_modules=['pytest_rerunfailures'],
-      entry_points={'pytest11': ['rerunfailures = pytest_rerunfailures']},
+      author='Leah Klearman, DataRobot',
+      url='https://github.com/datarobot/pytest-rerunfailures',
+      py_modules=['pytest-cleanrerun'],
+      entry_points={'pytest11': ['cleanrerun = pytest_cleanrerun']},
       install_requires=['pytest >= 2.8.7'],
       license='Mozilla Public License 2.0 (MPL 2.0)',
       keywords='py.test pytest rerun failures flaky',

--- a/test_pytest_cleanrerun.py
+++ b/test_pytest_cleanrerun.py
@@ -1,6 +1,6 @@
 import random
 import time
-import pytest_rerunfailures
+import pytest_cleanrerun
 
 try:
     import mock

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py{27,34,35,36,py,py3}-pytest{27,28,29,30,31,32,33},
 
 [testenv]
-commands = py.test test_pytest_rerunfailures.py {posargs}
+commands = py.test test_pytest_cleanrerun.py {posargs}
 deps =
     mock
     pytest28: pytest==2.8.*


### PR DESCRIPTION
## Rationally
Current fork aimed to improve rerun approach so it will be suitable for tests with module and session scoped fixtures.

## Changes
Added all scoped fixtures invalidation for current test item in case of test failure before rerun occurs.
Plugin able to track all related fixtures: direct injects, autouse, usefixture mark.
Fixtures invalidated gracefully with executing finalizer.


## Testing
The same functionality was run against current functional splits and reruns helped for several (about 8) tests to pass during runs:
https://jenkins.hq.datarobot.com/job/paralleled_functional_executor_TEST/307/
https://jenkins.hq.datarobot.com/job/paralleled_functional_executor_TEST/308/
https://jenkins.hq.datarobot.com/job/paralleled_functional_executor_TEST/309/
https://jenkins.hq.datarobot.com/job/paralleled_functional_executor_TEST/310/

## Jira
https://datarobot.atlassian.net/browse/QA-3033