### PR TITLE
[QA-3113] Downgrade mock version requirement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+4.1.dr3 (2018-05-14)
+================
+- Softer mock version dependecy 
+
+
 4.1.dr2 (2018-05-14)
 ================
 Moved rerun execution on testrun end:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pytest-rerunfailures',
-      version='4.1.dr2',
+      version='4.1.dr3',
       description='pytest plugin to re-run tests with fixture invalidation to eliminate flaky failures',
       long_description=(
           open('README.rst').read() +

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='pytest-rerunfailures',
       url='https://github.com/datarobot/pytest-rerunfailures',
       py_modules=['pytest_rerunfailures'],
       entry_points={'pytest11': ['rerunfailures = pytest_rerunfailures']},
-      install_requires=['pytest >= 2.8.7', 'mock==2.0.0'],
+      install_requires=['pytest >= 2.8.7', 'mock>=1.0.1'],
       license='Mozilla Public License 2.0 (MPL 2.0)',
       keywords='py.test pytest rerun failures flaky',
       classifiers=[


### PR DESCRIPTION
We run into an issue that DR test requirements related to mock version conflict: mock==1.0.1 vs mock==2.0.0 in rerun-failed package.
Related PR:
https://github.com/datarobot/DataRobot/pull/25192

As workaround added soft dependency for mock in  pytest-rerunfailures.