### PR TITLE
Fix for pytest-xdist plugin compatibility 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.1.dr5 (2018-08-07)
 ================
 - Pytest-xdist support added 
+- Added --max-tests-rerun param to do not perform reruns after some threshold
+- Added reruns time spends reporting
 
 
 4.1.dr4 (2018-06-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+4.1.dr5 (2018-08-07)
+================
+- Pytest-xdist support added 
+
+
 4.1.dr4 (2018-06-13)
 ================
 - Added possibility to persist rerun stats to json file

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,11 @@ Stats file fill consist next fields::
     rerun_trace - Test relevant tarces for teardown, setup and test call
     original_trace - Original test failure tarce appreared during main run 
 
+Skip reruns execution
+---------------------
+In case if it is not needed to perform reruns if many tests failed next param could be used:
+  ``--max-tests-rerun {threshold}``
+So if during testrun will occur more failed test then threshold value no reruns would be performed.
 
 Compatibility
 -------------

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -89,7 +89,7 @@ def pytest_addoption(parser):
         dest='max_tests_rerun',
         type=int,
         default=None,
-        help='provide path to export reruns artifact.'
+        help='max amount of failures at which reruns would be executed'
     )
 
 
@@ -486,7 +486,7 @@ class RerunPlugin(object):
     @contextmanager
     def _prepare_xdist(self, item):
         """
-        Explicetly changing current working test for xdist worker with rollback
+        Explicitly changing current working test for xdist worker with rollback
         to keep messaging flow safe
         """
         if self.xdist_worker:

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import pkg_resources
 import time
@@ -82,6 +83,14 @@ def pytest_addoption(parser):
         default='',
         help='provide path to export reruns artifact.'
     )
+    group._addoption(
+        '--max-tests-rerun',
+        action='store',
+        dest='max_tests_rerun',
+        type=int,
+        default=None,
+        help='provide path to export reruns artifact.'
+    )
 
 
 @pytest.hookimpl(trylast=True)
@@ -128,6 +137,8 @@ class RerunPlugin(object):
             lambda x: x.__class__.__name__ == 'WorkerInteractor', 
             pytest.config.pluginmanager.get_plugins()
         )), None)
+        self.reruns_time = 0
+        self.test_reports = {}
 
     def _failed_test(self, nodeid):
         """
@@ -203,6 +214,8 @@ class RerunPlugin(object):
             nodeid=item.nodeid, location=item.location)
         reports = runtestprotocol(item, nextitem=nextitem, log=False)
         reruns = self._get_reruns_count(item)
+        
+        self.test_reports[item.nodeid] = copy.deepcopy(reports)
 
         for report in reports:  # 3 reports: setup, call, teardown
             xfail = hasattr(report, 'wasxfail')
@@ -221,10 +234,34 @@ class RerunPlugin(object):
 
         # Last test of a testrun was performed
         if nextitem == None:
+            max_tests_reruns = item.config.option.max_tests_rerun
+            if max_tests_reruns and len(self.tests_to_rerun) > max_tests_reruns:
+                self._skip_reruns(
+                    max_tests_reruns,
+                    item.config.pluginmanager.getplugin("terminalreporter")
+                )
+                return True
+            rerun_start = time.time()
             self._execute_reruns()
             self._save_reruns_artifact(item.session)
-
+            self.reruns_time = time.time() - rerun_start
         return True
+
+    def _skip_reruns(self, max_tests_reruns, terminalreporter):
+        """
+        Skip reruns and republish reports
+        """
+        msg = "Too many failed test: %s with threshold of %s. Restore failures without reruns" % (
+            len(self.tests_to_rerun), max_tests_reruns
+        )
+        markup = {'red': True, "bold": True}
+        terminalreporter.write_sep("=", msg, **markup)
+
+        for item in self.tests_to_rerun:
+            for report in self.test_reports[item.nodeid]:
+                item.ihook.pytest_runtest_logreport(report=report)
+
+        self.tests_to_rerun = []
 
     def _execute_reruns(self):
         """
@@ -345,6 +382,12 @@ class RerunPlugin(object):
             tr._tw.sep("=", "rerun test summary info")
             for line in lines:
                 tr._tw.line(line)
+
+        msg = "Performed %s reruns in %2f seconds" % (len(self.tests_to_rerun), self.reruns_time)
+        markup = {'yellow': True, "bold": True}
+        tr.write_sep("=", msg, **markup)
+        if len(self.tests_to_rerun) == 0:
+            tr.stats['rerun'] = []
 
     def _show_rerun(self, terminalreporter, lines):
         """

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -123,6 +123,7 @@ class RerunPlugin(object):
             'total_reruns': 0,
             'total_resolved_by_reruns': 0
         }
+        # resolving xdist worker object
         self.xdist_worker = next(iter(filter(
             lambda x: x.__class__.__name__ == 'WorkerInteractor', 
             pytest.config.pluginmanager.get_plugins()
@@ -431,6 +432,7 @@ class RerunPlugin(object):
             return
 
         if self.xdist_worker:
+            # Adding xdist worker prefix to filepath to avoid stats overwrite
             path = artifact_path.split('/')
             path[-1] = self.xdist_worker.workerid + '_' + path[-1]
             artifact_path = '/'.join(path)
@@ -440,6 +442,10 @@ class RerunPlugin(object):
 
     @contextmanager
     def _prepare_xdist(self, item):
+        """
+        Explicetly changing current working test for xdist worker with rollback
+        to keep messaging flow safe
+        """
         if self.xdist_worker:
             current_index = self.xdist_worker.item_index
             self.xdist_worker.item_index = self.xdist_worker.session.items.index(item)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pytest-rerunfailures',
-      version='4.1.dr4',
+      version='4.1.dr5',
       description='pytest plugin to re-run tests with fixture invalidation to eliminate flaky failures',
       long_description=(
           open('README.rst').read() +


### PR DESCRIPTION
Fix for `pytest-xdist` plugin compatibility 

### Changes
`pytest-xdist` worker component provides additional assert of returning reports  relate to current scheduled test for execution. Thats  why original reruns failures works with it natively - it completes reruns just after tests failure before `runtest_protocol_complete` hook which is signal of end of test execution.

Current changes mimic such behavior. Also add reruns stats collection support for xdist launches such as each worker will generate separate stats with worker id prefix for filename.

### Testing
Local launches against synthetic test suite
